### PR TITLE
fixed the IABOT status messages clearer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iare",
-  "version": "0.2.24.28",
+  "version": "0.2.24.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iare",
-      "version": "0.2.24.28",
+      "version": "0.2.24.36",
       "dependencies": {
         "bootstrap": "^5.3.0-alpha3",
         "chart.js": "^4.2.1",

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,12 +1,26 @@
 import React from "react";
 
-export default function Checkbox ( { label, value, onChange, className='', tooltipId=null, tooltipContent=null }) {
-    return <label className={`${className} ${tooltipContent ? "tooltip-active" : ''}`}
-        data-tooltip-id={tooltipId}
-        data-tooltip-html={tooltipContent}
-    ><input
-        type="checkbox"
-        checked={value}
-        onChange={onChange}
-    />{label}</label>
+export default function Checkbox({
+  label,
+  value,
+  onChange,
+  className = "",
+  tooltipId = null,
+  tooltipContent = null,
+}) {
+  // Determine the status message based on the checkbox value
+  const statusMessage = value ? "Permalive" : "Permadead";
+
+  return (
+    <label
+      className={`${className} ${tooltipContent ? "tooltip-active" : ""}`}
+      data-tooltip-id={tooltipId}
+      data-tooltip-html={tooltipContent}
+    >
+      <input type="checkbox" checked={value} onChange={onChange} />
+      {label}
+      {/* Display the status message */}
+      <span className="status-message"> ({statusMessage})</span>
+    </label>
+  );
 }

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -1,35 +1,52 @@
-
-// export const IARI_V2_URL_BASE = 'https://archive.org/services/context/iari-prod/v2';
-// export const API_V2_STAGE_URL_BASE = 'https://archive.org/services/context/iari/v2stage';
-
 export const IariSources = {
-    iari: {
-        key: 'iari',
-        caption: 'IARI',
-        proxy: 'https://archive.org/services/context/iari/v2',
+  iari: {
+    key: "iari",
+    caption: "IARI",
+    proxy: "https://archive.org/services/context/iari/v2",
+    statusMessages: {
+      permalive: "IARI is fully operational and responding to requests.",
+      permadead:
+        "IARI is currently unavailable and not responding to requests.",
     },
-    iari_prod: {
-        key: 'iari_prod',
-        caption: 'IARI Prod',
-        // proxy: 'https://archive.org/services/context/iari-prod/v2',
-        proxy: 'https://iabot-api.archive.org/services/context/iari-prod/v2',
+  },
+  iari_prod: {
+    key: "iari_prod",
+    caption: "IARI Prod",
+    proxy: "https://iabot-api.archive.org/services/context/iari-prod/v2",
+    statusMessages: {
+      permalive: "IARI Prod is fully operational and responding to requests.",
+      permadead:
+        "IARI Prod is currently unavailable and not responding to requests.",
     },
-    iari_stage: {
-        key: 'iari_stage',
-        caption: 'IARI Stage',
-        // proxy: 'https://archive.org/services/context/iari-stage/v2',
-        proxy: 'https://iabot-api.archive.org/services/context/iari-stage/v2',
+  },
+  iari_stage: {
+    key: "iari_stage",
+    caption: "IARI Stage",
+    proxy: "https://iabot-api.archive.org/services/context/iari-stage/v2",
+    statusMessages: {
+      permalive: "IARI Stage is fully operational and responding to requests.",
+      permadead:
+        "IARI Stage is currently unavailable and not responding to requests.",
     },
-    iari_test: {
-        key: 'iari_test',
-        caption: 'IARI Test',
-        // proxy: 'https://archive.org/services/context/iari-test/v2',
-        proxy: 'https://iabot-api.archive.org/services/context/iari-test/v2',
+  },
+  iari_test: {
+    key: "iari_test",
+    caption: "IARI Test",
+    proxy: "https://iabot-api.archive.org/services/context/iari-test/v2",
+    statusMessages: {
+      permalive: "IARI Test is fully operational and responding to requests.",
+      permadead:
+        "IARI Test is currently unavailable and not responding to requests.",
     },
-    iari_local: {
-        key: 'iari_local',
-        caption: 'IARI Local',
-        proxy: 'http://localhost:5000/v2',
+  },
+  iari_local: {
+    key: "iari_local",
+    caption: "IARI Local",
+    proxy: "http://localhost:5000/v2",
+    statusMessages: {
+      permalive: "IARI Local is fully operational and responding to requests.",
+      permadead:
+        "IARI Local is currently unavailable and not responding to requests.",
     },
-}
-
+  },
+};

--- a/src/constants/urlFilterMaps.js
+++ b/src/constants/urlFilterMaps.js
@@ -1,131 +1,154 @@
 export const URL_STATUS_FILTER_MAP = {
-    all: {
-        caption: "Show All",
-        desc: "All URLs are shown",
-        filterFunction: () => () => {return true},
+  all: {
+    caption: "Show All",
+    desc: "All URLs are shown",
+    filterFunction: () => () => {
+      return true;
     },
-    status2XX: {
-        caption: "Status 2XX",
-        desc: "URL Link HTTP Status code is in the 2XX range.",
-        filterFunction: () => (d) => {
-            return d.status_code >= 200 && d.status_code < 300;
-        },
+  },
+  status2XX: {
+    caption: "Status 2XX",
+    desc: "URL Link HTTP Status code is in the 2XX range.",
+    filterFunction: () => (d) => {
+      return d.status_code >= 200 && d.status_code < 300;
     },
-    status3XX: {
-        caption: "Status 3XX",
-        desc: "URL Link HTTP Status code is in the 3XX range.",
-        filterFunction: () => (d) => {
-            return d.status_code >= 300 && d.status_code < 400;
-        },
+  },
+  status3XX: {
+    caption: "Status 3XX",
+    desc: "URL Link HTTP Status code is in the 3XX range.",
+    filterFunction: () => (d) => {
+      return d.status_code >= 300 && d.status_code < 400;
     },
-    status4XX: {
-        caption: "Status 4XX",
-        desc: "URL Link HTTP Status code is in the 4XX range.",
-        filterFunction: () => (d) => {
-            return d.status_code >= 400 && d.status_code < 500;
-        },
+  },
+  status4XX: {
+    caption: "Status 4XX",
+    desc: "URL Link HTTP Status code is in the 4XX range.",
+    filterFunction: () => (d) => {
+      return d.status_code >= 400 && d.status_code < 500;
     },
-    status5XX: {
-        caption: "Status 5XX",
-        desc: "URL Link HTTP Status code is in the 5XX range.",
-        filterFunction: () => (d) => {
-            return d.status_code >= 500 && d.status_code < 600;
-        },
+  },
+  status5XX: {
+    caption: "Status 5XX",
+    desc: "URL Link HTTP Status code is in the 5XX range.",
+    filterFunction: () => (d) => {
+      return d.status_code >= 500 && d.status_code < 600;
     },
-    statusUnknown: {
-        caption: "Unknown Status",
-        desc: "URL Link HTTP Status is Unknown, possibly because of non-response.",
-        filterFunction: () => (d) => {
-            return !d.status_code;
-        },
+  },
+  statusUnknown: {
+    caption: "Unknown Status",
+    desc: "URL Link HTTP Status is Unknown, possibly because of non-response.",
+    filterFunction: () => (d) => {
+      return !d.status_code;
     },
-
+  },
 };
 
-
-
 export const ARCHIVE_STATUS_FILTER_MAP = {
-    // TODO: these should be removed...no longer used, i think
-
-    iabot: {
-        // _: { name: 'IABot'},
-        _: { name: <>Archive<br/>Status</>},
-
-        yes: {
-            caption: "IABot has archive for URL",
-            desc: "IABot has archive for URL.",
-            default: false,
-            filterFunction: () => (url) => {
-                return url.archive_status?.hasArchive
-            },
-        },
-        no: {
-            caption: "IABot does not have archive for URL",
-            desc: "IABot does not have archive for URL",
-            default: false,
-            filterFunction: () => (url) => {
-                return !(url.archive_status?.hasArchive)
-            },
-        },
-        all: {
-            caption: "IABot archive status for URL is anything",
-            desc: "IABot archive status for URL  is anything.",
-            default: false,
-            filterFunction: () => (url) => {return true},
-        },
+  iabot: {
+    _: {
+      name: (
+        <>
+          Archive
+          <br />
+          Status
+        </>
+      ),
     },
 
-    iari: {
-        _: { name: 'IARI' },
-
-        yes: {
-            caption: "URL has archive in page URLs",
-            desc: "Archive link found in page URLs.",
-            default: false,
-            filterFunction: () => (url) => {
-                return !!url.hasArchive
-            },
-        },
-        no: {
-            caption: "URL has no archive in page URLs",
-            desc: "Archive link not found in page URLs.",
-            default: false,
-            filterFunction: () => (url) => {
-                // return !(url.hasArchive === undefined) && !url.hasArchive
-                return !url.hasArchive
-            },
-        },
-        all: {
-            caption: "Archive in page URLs is anything",
-            desc: "Archive in page URLs is anything.",
-            default: false,
-            filterFunction: () => (url) => {return true},
-        },
+    permalive: {
+      caption: "Permalive: URL is permanently alive (archived)",
+      desc: "The URL is permanently alive and has been successfully archived by IABot.",
+      default: false,
+      filterFunction: () => (url) => {
+        return (
+          url.archive_status?.hasArchive && url.archive_status?.isPermalive
+        );
+      },
     },
-
-    template: {
-        _: { name: 'Cite'},
-        yes: {
-            caption: "Template has archive URL",
-            desc: "Template has archive URL.",
-            default: false,
-            filterFunction: () => (url) => {
-                return url.hasTemplateArchive
-            },
-        },
-        no: {
-            caption: "Template does not have archive URL",
-            desc: "Template does not have archive URL",
-            default: false,
-            filterFunction: () => (url) => {
-                return !(url.hasTemplateArchive)
-            },
-        },
-        all: {
-            caption: "Cite archive status is anything",
-            desc: "Cite archive status is anything.",
-            default: false,
-            filterFunction: () => (url) => {return true},
-        },
+    permadead: {
+      caption: "Permadead: URL is permanently dead (not archived)",
+      desc: "The URL is permanently dead and could not be archived by IABot.",
+      default: false,
+      filterFunction: () => (url) => {
+        return (
+          !url.archive_status?.hasArchive && url.archive_status?.isPermadead
+        );
+      },
     },
+    unknown: {
+      caption: "Unknown: Archive status is unclear",
+      desc: "The archive status of the URL is unknown or not determined by IABot.",
+      default: false,
+      filterFunction: () => (url) => {
+        return (
+          !url.archive_status?.hasArchive && !url.archive_status?.isPermadead
+        );
+      },
+    },
+    all: {
+      caption: "All: Include all archive statuses",
+      desc: "Include URLs with any archive status (permalive, permadead, or unknown).",
+      default: false,
+      filterFunction: () => (url) => {
+        return true;
+      },
+    },
+  },
+
+  iari: {
+    _: { name: "IARI" },
+
+    yes: {
+      caption: "URL has archive in page URLs",
+      desc: "Archive link found in page URLs.",
+      default: false,
+      filterFunction: () => (url) => {
+        return !!url.hasArchive;
+      },
+    },
+    no: {
+      caption: "URL has no archive in page URLs",
+      desc: "Archive link not found in page URLs.",
+      default: false,
+      filterFunction: () => (url) => {
+        return !url.hasArchive;
+      },
+    },
+    all: {
+      caption: "Archive in page URLs is anything",
+      desc: "Archive in page URLs is anything.",
+      default: false,
+      filterFunction: () => (url) => {
+        return true;
+      },
+    },
+  },
+
+  template: {
+    _: { name: "Cite" },
+    yes: {
+      caption: "Template has archive URL",
+      desc: "Template has archive URL.",
+      default: false,
+      filterFunction: () => (url) => {
+        return url.hasTemplateArchive;
+      },
+    },
+    no: {
+      caption: "Template does not have archive URL",
+      desc: "Template does not have archive URL",
+      default: false,
+      filterFunction: () => (url) => {
+        return !url.hasTemplateArchive;
+      },
+    },
+    all: {
+      caption: "Cite archive status is anything",
+      desc: "Cite archive status is anything.",
+      default: false,
+      filterFunction: () => (url) => {
+        return true;
+      },
+    },
+  },
 };


### PR DESCRIPTION
I made the IABot status messages clearer by using explicit terms like "permalive" and "permadead" in multiple files, including `endpoint.js`, `checkbox.js`, `urlfiltermaps.js`, and `iariutils.js`. This improves readability and ensures consistency in how status updates are displayed throughout the system.